### PR TITLE
belle-sip should depend on bctoolbox

### DIFF
--- a/net-voip/belle-sip/belle-sip-1.6.3.ebuild
+++ b/net-voip/belle-sip/belle-sip-1.6.3.ebuild
@@ -18,6 +18,7 @@ IUSE="examples test -tunnel"
 REQUIRED_USE=""
 
 DEPEND="${RDEPEND}
+	net-libs/bctoolbox
 	dev-java/antlr:3
 	dev-libs/antlr-c
 	dev-util/intltool


### PR DESCRIPTION
Otherwise build fails with:

CMake Error at CMakeLists.txt:97 (find_package):
  By not providing "FindBcToolbox.cmake" in CMAKE_MODULE_PATH this project
  has asked CMake to find a package configuration file provided by
  "BcToolbox", but CMake did not find one.

  Could not find a package configuration file provided by "BcToolbox"
  (requested version 0.5.0) with any of the following names:

    BcToolboxConfig.cmake
    bctoolbox-config.cmake

  Add the installation prefix of "BcToolbox" to CMAKE_PREFIX_PATH or set
  "BcToolbox_DIR" to a directory containing one of the above files.  If
  "BcToolbox" provides a separate development package or SDK, be sure it has
  been installed.