### PR TITLE
net-im/psi: Specify slot for dev-qt/qtimageformats

### DIFF
--- a/net-im/psi/psi-9999.ebuild
+++ b/net-im/psi/psi-9999.ebuild
@@ -61,7 +61,7 @@ DEPEND="
 	)
 "
 RDEPEND="${DEPEND}
-	dev-qt/qtimageformats
+	dev-qt/qtimageformats:5
 "
 
 RESTRICT="test iconsets? ( bindist )"


### PR DESCRIPTION
Should be useful when Qt6 is added