### PR TITLE
fix for fatal error: ui_sendbuttontemplateseditor.h: No such file or …

### DIFF
--- a/net-im/psi/psi-9999.ebuild
+++ b/net-im/psi/psi-9999.ebuild
@@ -151,6 +151,18 @@ src_configure() {
 }
 
 src_compile() {
+	local qtbin=/usr/$(get_libdir)/qt5/bin
+	local ui rel outdir out
+
+	while IFS= read -r -d '' ui; do
+		rel=${ui#${S}/}
+		outdir=${BUILD_DIR}/$(dirname "${rel}")
+		out=${outdir}/ui_$(basename "${ui}" .ui).h
+
+		mkdir -p "${outdir}" || die
+		"${qtbin}"/uic "${ui}" -o "${out}" || die "uic failed for ${rel}"
+	done < <(find "${S}" -name '*.ui' -print0)
+
 	cmake_src_compile
 	use doc && emake -C doc api_public
 }


### PR DESCRIPTION
So there were errors like these:
```
fatal error: ui_sendbuttontemplateseditor.h: No such file or directory
fatal error: ui_proxy.h: No such file or directory
```

And I was not able to build psi for a while.

Fixed by  explicitly generating all ui_*.h headers in src_compile() using uic before invoking cmake_src_compile. Maybe it's not a good fix, but at least you'll know there's a problem and you can solve it your own way.